### PR TITLE
Find command: Improve defensive programming

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -82,4 +82,16 @@ public class ArgumentMultimap {
     public int numberOfUniquePrefixes() {
         return this.argMultimap.size() - 1;
     }
+
+    /**
+     * Checks if the {@code ArgumentMultimap} contains a valid entry for the specified prefix.
+     *
+     * @param prefix the {@code Prefix} we want to check for in the argument map.
+     * @return {@code True} if the prefix is present with exactly one non-empty argument;
+     *         {@code False} otherwise.
+     */
+    public boolean containsValidSinglePrefix(Prefix prefix) {
+        return argMultimap.containsKey(prefix) && argMultimap.get(prefix).size() == 1
+                && !argMultimap.get(prefix).get(0).isEmpty();
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -90,8 +90,9 @@ public class ArgumentMultimap {
      * @return {@code True} if the prefix is present with exactly one non-empty argument;
      *         {@code False} otherwise.
      */
-    public boolean hasValidSingleString(Prefix prefix) {
-        return argMultimap.containsKey(prefix) && argMultimap.get(prefix).size() == 1
+    public boolean hasSingleValidString(Prefix prefix) {
+        return argMultimap.containsKey(prefix)
+                && argMultimap.get(prefix).size() == 1
                 && !argMultimap.get(prefix).get(0).isEmpty();
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -84,13 +84,13 @@ public class ArgumentMultimap {
     }
 
     /**
-     * Checks if the {@code ArgumentMultimap} contains a valid entry for the specified prefix.
+     * Checks if the {@code ArgumentMultimap} contains a single valid string for the specified prefix.
      *
      * @param prefix the {@code Prefix} we want to check for in the argument map.
      * @return {@code True} if the prefix is present with exactly one non-empty argument;
      *         {@code False} otherwise.
      */
-    public boolean containsValidSinglePrefix(Prefix prefix) {
+    public boolean hasValidSingleString(Prefix prefix) {
         return argMultimap.containsKey(prefix) && argMultimap.get(prefix).size() == 1
                 && !argMultimap.get(prefix).get(0).isEmpty();
     }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -43,19 +43,19 @@ public class FindCommandParser implements Parser<FindCommand> {
         FieldContainsKeywordsPredicate predicate = null;
         String[] keywords;
 
-        if (argMultimap.containsValidSinglePrefix(PREFIX_NAME)) {
+        if (argMultimap.hasValidSingleString(PREFIX_NAME)) {
             keywords = argMultimap.getValue(PREFIX_NAME).get().split("\\s+");
             predicate = new FieldContainsKeywordsPredicate(Arrays.asList(keywords), "name");
-        } else if (argMultimap.containsValidSinglePrefix(PREFIX_ID)) {
+        } else if (argMultimap.hasValidSingleString(PREFIX_ID)) {
             keywords = argMultimap.getValue(PREFIX_ID).get().split("\\s+");
             predicate = new FieldContainsKeywordsPredicate(Arrays.asList(keywords), "id");
-        } else if (argMultimap.containsValidSinglePrefix(PREFIX_WARD)) {
+        } else if (argMultimap.hasValidSingleString(PREFIX_WARD)) {
             keywords = argMultimap.getValue(PREFIX_WARD).get().split("\\s+");
             predicate = new FieldContainsKeywordsPredicate(Arrays.asList(keywords), "ward");
-        } else if (argMultimap.containsValidSinglePrefix(PREFIX_DIAGNOSIS)) {
+        } else if (argMultimap.hasValidSingleString(PREFIX_DIAGNOSIS)) {
             keywords = argMultimap.getValue(PREFIX_DIAGNOSIS).get().split("\\s+");
             predicate = new FieldContainsKeywordsPredicate(Arrays.asList(keywords), "diagnosis");
-        } else if (argMultimap.containsValidSinglePrefix(PREFIX_MEDICATION)) {
+        } else if (argMultimap.hasValidSingleString(PREFIX_MEDICATION)) {
             keywords = argMultimap.getValue(PREFIX_MEDICATION).get().split("\\s+");
             predicate = new FieldContainsKeywordsPredicate(Arrays.asList(keywords), "medication");
         } else {

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -8,7 +8,9 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_WARD;
 
 import java.util.Arrays;
+import java.util.logging.Logger;
 
+import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.FieldContainsKeywordsPredicate;
@@ -17,6 +19,8 @@ import seedu.address.model.person.FieldContainsKeywordsPredicate;
  * Parses input arguments and creates a new FindCommand object
  */
 public class FindCommandParser implements Parser<FindCommand> {
+
+    private static final Logger logger = LogsCenter.getLogger(AddressBookParser.class);
 
     /**
      * Parses the given {@code String} of arguments in the context of the FindCommand
@@ -39,22 +43,23 @@ public class FindCommandParser implements Parser<FindCommand> {
         FieldContainsKeywordsPredicate predicate = null;
         String[] keywords;
 
-        if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
+        if (argMultimap.containsValidSinglePrefix(PREFIX_NAME)) {
             keywords = argMultimap.getValue(PREFIX_NAME).get().split("\\s+");
             predicate = new FieldContainsKeywordsPredicate(Arrays.asList(keywords), "name");
-        } else if (argMultimap.getValue(PREFIX_ID).isPresent()) {
+        } else if (argMultimap.containsValidSinglePrefix(PREFIX_ID)) {
             keywords = argMultimap.getValue(PREFIX_ID).get().split("\\s+");
             predicate = new FieldContainsKeywordsPredicate(Arrays.asList(keywords), "id");
-        } else if (argMultimap.getValue(PREFIX_WARD).isPresent()) {
+        } else if (argMultimap.containsValidSinglePrefix(PREFIX_WARD)) {
             keywords = argMultimap.getValue(PREFIX_WARD).get().split("\\s+");
             predicate = new FieldContainsKeywordsPredicate(Arrays.asList(keywords), "ward");
-        } else if (argMultimap.getValue(PREFIX_DIAGNOSIS).isPresent()) {
+        } else if (argMultimap.containsValidSinglePrefix(PREFIX_DIAGNOSIS)) {
             keywords = argMultimap.getValue(PREFIX_DIAGNOSIS).get().split("\\s+");
             predicate = new FieldContainsKeywordsPredicate(Arrays.asList(keywords), "diagnosis");
-        } else if (argMultimap.getValue(PREFIX_MEDICATION).isPresent()) {
+        } else if (argMultimap.containsValidSinglePrefix(PREFIX_MEDICATION)) {
             keywords = argMultimap.getValue(PREFIX_MEDICATION).get().split("\\s+");
             predicate = new FieldContainsKeywordsPredicate(Arrays.asList(keywords), "medication");
         } else {
+            logger.warning("Invalid input for find command detected!");
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -43,19 +43,19 @@ public class FindCommandParser implements Parser<FindCommand> {
         FieldContainsKeywordsPredicate predicate = null;
         String[] keywords;
 
-        if (argMultimap.hasValidSingleString(PREFIX_NAME)) {
+        if (argMultimap.hasSingleValidString(PREFIX_NAME)) {
             keywords = argMultimap.getValue(PREFIX_NAME).get().split("\\s+");
             predicate = new FieldContainsKeywordsPredicate(Arrays.asList(keywords), "name");
-        } else if (argMultimap.hasValidSingleString(PREFIX_ID)) {
+        } else if (argMultimap.hasSingleValidString(PREFIX_ID)) {
             keywords = argMultimap.getValue(PREFIX_ID).get().split("\\s+");
             predicate = new FieldContainsKeywordsPredicate(Arrays.asList(keywords), "id");
-        } else if (argMultimap.hasValidSingleString(PREFIX_WARD)) {
+        } else if (argMultimap.hasSingleValidString(PREFIX_WARD)) {
             keywords = argMultimap.getValue(PREFIX_WARD).get().split("\\s+");
             predicate = new FieldContainsKeywordsPredicate(Arrays.asList(keywords), "ward");
-        } else if (argMultimap.hasValidSingleString(PREFIX_DIAGNOSIS)) {
+        } else if (argMultimap.hasSingleValidString(PREFIX_DIAGNOSIS)) {
             keywords = argMultimap.getValue(PREFIX_DIAGNOSIS).get().split("\\s+");
             predicate = new FieldContainsKeywordsPredicate(Arrays.asList(keywords), "diagnosis");
-        } else if (argMultimap.hasValidSingleString(PREFIX_MEDICATION)) {
+        } else if (argMultimap.hasSingleValidString(PREFIX_MEDICATION)) {
             keywords = argMultimap.getValue(PREFIX_MEDICATION).get().split("\\s+");
             predicate = new FieldContainsKeywordsPredicate(Arrays.asList(keywords), "medication");
         } else {

--- a/src/main/java/seedu/address/model/person/FieldContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/FieldContainsKeywordsPredicate.java
@@ -1,5 +1,7 @@
 package seedu.address.model.person;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.List;
 import java.util.function.Predicate;
 
@@ -18,6 +20,8 @@ public class FieldContainsKeywordsPredicate implements Predicate<Person> {
      * @param field The field to be searched
      */
     public FieldContainsKeywordsPredicate(List<String> keywords, String field) {
+        requireNonNull(field);
+        requireNonNull(keywords);
         this.keywords = keywords;
         this.field = field;
     }

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -38,4 +38,10 @@ public class FindCommandParserTest {
         assertParseSuccess(parser, "    n/  \n Amy \n \t Ben  \t", expectedFindCommand);
     }
 
+    @Test
+    public void parse_validPrefixEmptyKeyword_throwsParseException() {
+        assertParseFailure(parser, " i/        ", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                FindCommand.MESSAGE_USAGE));
+    }
+
 }


### PR DESCRIPTION
Defensive programming for the find command is not robust enough.

Having better defensive programming measures can make the product more user friendly as there will be less unexpected cases.

Let's,
* handle the case where a user inputs white spaces after their field (e.g. "find i/       ")
* include logging for debugging purposes