### PR TITLE
Add correct JsonCreator constructor

### DIFF
--- a/src/main/java/seedu/address/storage/JsonAdaptedAppointment.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedAppointment.java
@@ -3,6 +3,7 @@ package seedu.address.storage;
 import java.time.LocalDateTime;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 import seedu.address.commons.exceptions.IllegalValueException;
@@ -19,7 +20,6 @@ public class JsonAdaptedAppointment {
     /**
      * Constructor to convert an Appointment object into JsonAdaptedAppointment
      */
-    @JsonCreator
     public JsonAdaptedAppointment(Appointment source) {
         if (source == null) {
             this.description = null;
@@ -30,6 +30,18 @@ public class JsonAdaptedAppointment {
             this.start = source.getStart();
             this.end = source.getEnd();
         }
+    }
+
+    /**
+     * Constructor for Jackson to use during deserialization
+     */
+    @JsonCreator
+    public JsonAdaptedAppointment(@JsonProperty("description") String description,
+                                  @JsonProperty("start") LocalDateTime start,
+                                  @JsonProperty("end") LocalDateTime end) {
+        this.description = description;
+        this.start = start;
+        this.end = end;
     }
 
     /**


### PR DESCRIPTION
Closes #106

When there are persons with appointments loaded into the storage, there is a `JsonMappingException` as the appointment fields are unable deserialized into an instance of the Appointment class.

This issue results due to a `@JsonCreator` constructor not having the appropriate fields.

Let's fix this by adding an appropriate `@JsonCreator` constructor.