### PR TITLE
Bug fix: Improve defensive programming measures

### DIFF
--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -137,7 +137,7 @@ public class ModelManager implements Model {
 
     private void initializeAppointmentList() {
         AppointmentContainsDatePredicate predicate = new AppointmentContainsDatePredicate(LocalDate.now());
-        filteredAppointments.setPredicate(predicate);
+        updateFilteredAppointmentList(predicate);
     }
 
     /**

--- a/src/main/java/seedu/address/model/appointment/AppointmentContainsDatePredicate.java
+++ b/src/main/java/seedu/address/model/appointment/AppointmentContainsDatePredicate.java
@@ -1,5 +1,6 @@
 package seedu.address.model.appointment;
 
+import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.DateUtil.DATE_FORMATTER;
 
 import java.time.LocalDate;
@@ -21,16 +22,20 @@ public class AppointmentContainsDatePredicate implements Predicate<Person> {
 
     @Override
     public boolean test(Person person) {
+        requireNonNull(person);
         if (person.getAppointment() == null) {
             return false;
         } else if (this.date == null) {
             return true;
         }
 
-        LocalDate startDate = person.getAppointment().getStart().toLocalDate();
-        LocalDate endDate = person.getAppointment().getEnd().toLocalDate();
+        LocalDate startDate = person.getAppointmentStart().toLocalDate();
+        LocalDate endDate = person.getAppointmentEnd().toLocalDate();
 
-        return !this.date.isBefore(startDate) && !this.date.isAfter(endDate);
+        boolean isDateBeforeStart = this.date.isBefore(startDate);
+        boolean isDateAfterEnd = this.date.isAfter(endDate);
+
+        return !isDateBeforeStart && !isDateAfterEnd;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/FieldContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/FieldContainsKeywordsPredicate.java
@@ -28,6 +28,7 @@ public class FieldContainsKeywordsPredicate implements Predicate<Person> {
 
     @Override
     public boolean test(Person person) {
+        requireNonNull(person);
         return switch (this.field) {
         case "name" -> keywords.stream()
                 .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getName().toString(), keyword));

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -1,5 +1,6 @@
 package seedu.address.model.person;
 
+import java.time.LocalDateTime;
 import java.util.Objects;
 
 import seedu.address.commons.util.ToStringBuilder;
@@ -100,6 +101,34 @@ public class Person {
 
         return otherPerson != null
                 && otherPerson.getId().equals(getId());
+    }
+
+    /**
+     * Returns the start time of the person's appointment if it exists.
+     *
+     * @return the start time of the appointment as a {@code LocalDateTime},
+     *         or {@code null} if the person does not have an appointment.
+     */
+    public LocalDateTime getAppointmentStart() {
+        if (this.appointment == null) {
+            return null;
+        }
+
+        return appointment.getStart();
+    }
+
+    /**
+     * Returns the end time of the person's appointment if it exists.
+     *
+     * @return the end time of the appointment as a {@code LocalDateTime},
+     *         or {@code null} if the person does not have an appointment.
+     */
+    public LocalDateTime getAppointmentEnd() {
+        if (this.appointment == null) {
+            return null;
+        }
+
+        return appointment.getEnd();
     }
 
     /**

--- a/src/test/java/seedu/address/model/appointment/AppointmentContainsDatePredicateTest.java
+++ b/src/test/java/seedu/address/model/appointment/AppointmentContainsDatePredicateTest.java
@@ -102,13 +102,17 @@ public class AppointmentContainsDatePredicateTest {
         predicate = new AppointmentContainsDatePredicate(null);
         assertFalse(predicate.test(new PersonBuilder().build()));
 
-        // Non-matching dates
+        // Date given is before the appointment
         predicate = new AppointmentContainsDatePredicate(LocalDate.parse("01-01-2023", DATE_FORMATTER));
         Person p = new PersonBuilder()
                 .withAppointment("Surgery",
                         LocalDateTime.parse("23-10-2024-12-00", DATE_TIME_FORMATTER),
                         LocalDateTime.parse("23-10-2024-14-00", DATE_TIME_FORMATTER))
                 .build();
+        assertFalse(predicate.test(p));
+
+        // Date given is after the appointment
+        predicate = new AppointmentContainsDatePredicate(LocalDate.parse("01-01-2025", DATE_FORMATTER));
         assertFalse(predicate.test(p));
     }
 


### PR DESCRIPTION
The test methods in the Predicate classes do not check if person is null.

requiring the person to be non null adds an additional layer of check to be done, making our product less susceptible to bugs.