### PR TITLE
Bug fix: Alter diagnosis field constraints

### DIFF
--- a/src/main/java/seedu/address/model/person/Diagnosis.java
+++ b/src/main/java/seedu/address/model/person/Diagnosis.java
@@ -9,10 +9,9 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Diagnosis {
     public static final String MESSAGE_CONSTRAINTS =
-            "DIAGNOSIS can only contain alphabets and the following special characters -> .()/- "
-                    + "(e.g., - A. fib (Atrial Fibrillation).\n"
-                    + "It can be an empty string at the point of initialisation, as diagnosis may not be done yet.\n";
-    public static final String VALIDATION_REGEX = "^[A-Za-z0-9\\s.()/-]*|^$";
+            "Diagnosis must contain at least 1 alphabetic character, and has a limit of 100 characters.\n"
+            + "It cannot be empty.";
+    public static final String VALIDATION_REGEX = "^(?=.*[A-Za-z]).{1,100}$";
     public final String value;
 
     /**

--- a/src/test/java/seedu/address/model/person/DiagnosisTest.java
+++ b/src/test/java/seedu/address/model/person/DiagnosisTest.java
@@ -1,0 +1,59 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class DiagnosisTest {
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Diagnosis(null));
+    }
+
+    @Test
+    public void constructor_invalidDiagnosis_throwsIllegalArgumentException() {
+        String invalidDiagnosis = "";
+        assertThrows(IllegalArgumentException.class, () -> new Diagnosis(invalidDiagnosis));
+    }
+
+    @Test
+    public void isValidDiagnosis() {
+        // null Diagnosis
+        assertThrows(NullPointerException.class, () -> Diagnosis.isValidDiagnosis(null));
+
+        // invalid Diagnosis
+        assertFalse(Diagnosis.isValidDiagnosis("")); // empty string
+        assertFalse(Diagnosis.isValidDiagnosis("    ")); // spaces only
+        assertFalse(Diagnosis.isValidDiagnosis("()-3351!*#&$!#")); // only non-alphabetic characters
+        assertFalse(Diagnosis.isValidDiagnosis("This diagnosis is super duper duper duper duper duper duper "
+                + "long and is most definitely longer than 100 characters")); // longer than 100 characters
+
+        // valid Diagnosis
+        assertTrue(Diagnosis.isValidDiagnosis("coughing and bleeding")); // only lowercase alphabetic characters
+        assertTrue(Diagnosis.isValidDiagnosis("Coughing and Bleeding")); // mix of upper and lower case
+        assertTrue(Diagnosis.isValidDiagnosis("Coughing, Bleeding and Wheezing!")); // with special characters
+        assertTrue(Diagnosis.isValidDiagnosis("Coughing on 3 occasions")); // with digit
+    }
+
+    @Test
+    public void equals() {
+        Diagnosis diagnosis = new Diagnosis("Valid Diagnosis");
+
+        // same values -> returns true
+        assertTrue(diagnosis.equals(new Diagnosis("Valid Diagnosis")));
+
+        // same object -> returns true
+        assertTrue(diagnosis.equals(diagnosis));
+
+        // null -> returns false
+        assertFalse(diagnosis.equals(null));
+
+        // different types -> returns false
+        assertFalse(diagnosis.equals(5.0f));
+
+        // different values -> returns false
+        assertFalse(diagnosis.equals(new Diagnosis("Other Valid Diagnosis")));
+    }
+}


### PR DESCRIPTION
Diagnosis fields has additional restrictions that may not be practical for users.

Altering the diagnosis field constraints can allow for greater real world modelling.

Let's make diagnosis field,
* accept any characters
* must have at least 1 alphabetic character
* have a limit of 100 characters

Also added testing for diagnosis class.