### PR TITLE
Improve error message for DateTimeParseException

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -3,7 +3,6 @@ package seedu.address.logic.parser;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.DateUtil.DATE_FORMATTER;
 import static seedu.address.commons.util.DateUtil.DATE_TIME_FORMATTER;
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -14,7 +13,6 @@ import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
-import seedu.address.logic.commands.ScheduleDateCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Diagnosis;
@@ -32,6 +30,10 @@ import seedu.address.model.tag.Tag;
 public class ParserUtil {
 
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
+    public static final String DATETIME_INVALID_INDEX = "Could not recognise the date and time provided, please use "
+            + "the format dd-MM-yyyy-HH-mm.";
+    public static final String DATE_INVALID_INDEX = "Could not recognise the date provided, please use the format "
+            + "dd-MM-yyyy.";
 
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
@@ -220,7 +222,7 @@ public class ParserUtil {
         try {
             return LocalDateTime.parse(trimmedDateTime, DATE_TIME_FORMATTER);
         } catch (DateTimeParseException e) {
-            throw new ParseException("Invalid date-time format: " + trimmedDateTime, e);
+            throw new ParseException(DATETIME_INVALID_INDEX + "\nInput causing the error: " + trimmedDateTime, e);
         }
     }
 
@@ -236,8 +238,7 @@ public class ParserUtil {
         try {
             return LocalDate.parse(trimmedDate, DATE_FORMATTER);
         } catch (DateTimeParseException e) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    ScheduleDateCommand.MESSAGE_USAGE), e);
+            throw new ParseException(DATE_INVALID_INDEX + "\nInput causing the error: " + trimmedDate, e);
         }
     }
 

--- a/src/test/java/seedu/address/logic/parser/ScheduleDateCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ScheduleDateCommandParserTest.java
@@ -1,8 +1,8 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.logic.parser.ParserUtil.DATE_INVALID_INDEX;
 
 import java.time.LocalDate;
 
@@ -27,16 +27,15 @@ public class ScheduleDateCommandParserTest {
     @Test
     public void parse_invalidArgs_throwsParseException() {
         // Test with invalid date format
-        assertParseFailure(parser, "2024-10-12", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                ScheduleDateCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "2024-10-12",
+                DATE_INVALID_INDEX + "\nInput causing the error: " + "2024-10-12");
 
         // Test with completely invalid input
-        assertParseFailure(parser, "invalidDate", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                ScheduleDateCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "invalidDate",
+                DATE_INVALID_INDEX + "\nInput causing the error: " + "invalidDate");
 
         // Test with missing input
-        assertParseFailure(parser, "", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                ScheduleDateCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "", DATE_INVALID_INDEX + "\nInput causing the error: ");
     }
 }
 


### PR DESCRIPTION
DateTimeParseException does not print out a very user friendly error message.

It might be beneficial to introduce a more human-like error response to improve user experience.

Let's change the error message returned during
DateTImeParseExceptions.