### PR TITLE
Improve command result for a few commands

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -37,7 +37,7 @@ public class Messages {
      */
     public static String format(Person person) {
         final StringBuilder builder = new StringBuilder();
-        builder.append("Name: ")
+        builder.append(" Name: ")
                 .append(person.getName())
                 .append("\n ID: ")
                 .append(person.getId())
@@ -47,9 +47,9 @@ public class Messages {
                 .append(person.getDiagnosis())
                 .append("\n Medication: ")
                 .append(person.getMedication())
-                .append("\n\n Notes: ")
+                .append("\n Notes: ")
                 .append(person.getNotes().toString().isEmpty() ? "-" : person.getNotes())
-                .append("\n\n Appointment: ")
+                .append("\n Appointment: ")
                 .append(person.getAppointment() == null ? "-" : person.getAppointment().toString());
         // .append("; Tags: ");
 

--- a/src/main/java/seedu/address/logic/commands/AddAppointmentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddAppointmentCommand.java
@@ -36,7 +36,7 @@ public class AddAppointmentCommand extends Command {
             + PREFIX_END + " 21-12-2024-23-59 "
             + "\n Datetime is in the form of dd-MM-yyyy-HH-mm";
 
-    public static final String MESSAGE_ADD_APPOINTMENT_SUCCESS = "Added Appointment to Person: %1$s";
+    public static final String MESSAGE_ADD_APPOINTMENT_SUCCESS = "Added Appointment to Person: \n\n%1$s";
     private final Index index;
     private final Appointment appointment;
     /**
@@ -74,7 +74,7 @@ public class AddAppointmentCommand extends Command {
         model.setPerson(personToEdit, editedPerson);
 
         //return new CommandResult(null);
-        return new CommandResult(String.format(MESSAGE_ADD_APPOINTMENT_SUCCESS, editedPerson));
+        return new CommandResult(String.format(MESSAGE_ADD_APPOINTMENT_SUCCESS, Messages.format(editedPerson)));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -35,7 +35,7 @@ public class AddCommand extends Command {
             + PREFIX_DIAGNOSIS + "TYPE 1 DIABETES "
             + PREFIX_MEDICATION + "METFORMIN ";
 
-    public static final String MESSAGE_SUCCESS = "New patient added: %1$s";
+    public static final String MESSAGE_SUCCESS = "New patient added: \n\n%1$s";
     public static final String MESSAGE_DUPLICATE_PERSON = "This patient already exists in the address book";
 
     private final Person toAdd;

--- a/src/main/java/seedu/address/logic/commands/AddNotesCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddNotesCommand.java
@@ -28,7 +28,7 @@ public class AddNotesCommand extends Command {
             + PREFIX_NOTES + "[NOTES]\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_NOTES + "Patient is prone to falling.";
-    public static final String MESSAGE_ADD_NOTES_SUCCESS = "Added notes to Patient: %1$s";
+    public static final String MESSAGE_ADD_NOTES_SUCCESS = "Added notes to Patient: \n\n%1$s";
     public static final String MESSAGE_DELETE_NOTES_SUCCESS = "Removed notes from Patient: %1$s";
 
     private final Index index;

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -23,7 +23,7 @@ public class DeleteCommand extends Command {
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
 
-    public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
+    public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: \n\n%1$s";
 
     private final Index targetIndex;
 

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -47,7 +47,7 @@ public class EditCommand extends Command {
             + PREFIX_ID + "P12345 "
             + PREFIX_WARD + "A2";
 
-    public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
+    public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: \n\n%1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book.";
 


### PR DESCRIPTION
Closes #182 

- Improved command result by separating command description and person description to new lines for the following commands:
   1) makeappt
   2) add
   3) addnotes
   4) delete
   5) edit

- Slight modificaiton to Messages:format method to remove separation lines for notes and appointment fields