### PR TITLE
Fix command format and remove case sensitivity

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -155,17 +155,17 @@ Examples:
 
 [Back to Table of Contents](#table-of-contents)
 
-### Adding notes to a patient : `addNotes`
+### Adding notes to a patient : `addnotes`
 
 Adds notes to an existing person in the address book.
 
-Format: `addNotes INDEX pn/NOTES`
+Format: `addnotes INDEX pn/NOTES`
 
 * Adds notes to the person at the specified `INDEX`. The index refers to the index number shown in the displayed person list. The index **must be a positive integer** 1, 2, 3, …​
 
 Examples:
-*  `addNotes 1 pn/Patient is prone to falling`
-*  `addNotes 2 pn/Patient requires frequent checkups`
+*  `addnotes 1 pn/Patient is prone to falling`
+*  `addnotes 2 pn/Patient requires frequent checkups`
 
 [Back to Table of Contents](#table-of-contents)
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -170,17 +170,17 @@ Examples:
 
 [Back to Table of Contents](#table-of-contents)
 
-### Deleting notes from a patient : `delNotes`
+### Deleting notes from a patient : `delnotes`
 
 Deletes notes from an existing person in the address book.
 
-Format: `delNotes INDEX`
+Format: `delnotes INDEX`
 
 * Deletes notes to the person at the specified `INDEX`. The index refers to the index number shown in the displayed person list. The index **must be a positive integer** 1, 2, 3, …​ 
 * The person specified must have notes for this command to work.
 
 Examples:
-*  `delNotes 1`
+*  `delnotes 1`
 
 [Back to Table of Contents](#table-of-contents)
 

--- a/src/main/java/seedu/address/logic/commands/AddNotesCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddNotesCommand.java
@@ -19,7 +19,7 @@ import seedu.address.model.person.Person;
  */
 public class AddNotesCommand extends Command {
 
-    public static final String COMMAND_WORD = "add_notes";
+    public static final String COMMAND_WORD = "addnotes";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the patient notes of the patient identified "
             + "by the index number used in the last patient listing. "

--- a/src/main/java/seedu/address/logic/commands/DeleteNotesCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteNotesCommand.java
@@ -17,7 +17,7 @@ import seedu.address.model.person.Person;
  */
 public class DeleteNotesCommand extends Command {
 
-    public static final String COMMAND_WORD = "delNotes";
+    public static final String COMMAND_WORD = "delnotes";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the patient notes from the person identified by the index number used in the "

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -57,7 +57,7 @@ public class AddressBookParser {
         // Lower level log messages are used sparingly to minimize noise in the code.
         logger.fine("Command word: " + commandWord + "; Arguments: " + arguments);
 
-        switch (commandWord) {
+        switch (commandWord.toLowerCase()) {
 
         case AddCommand.COMMAND_WORD:
             logger.fine(String.format("Add command identified, parsing args..."));


### PR DESCRIPTION
Changes made:
 
1.  Changed the command format of addnotes to have no underscore
2.  Changed the command format of delnotes to have no underscore
3.  Made it such that user inputs are not case sensitive for commands

