### PR TITLE
Disallow overlapping appointments

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddAppointmentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddAppointmentCommand.java
@@ -37,6 +37,8 @@ public class AddAppointmentCommand extends Command {
             + "\n Datetime is in the form of dd-MM-yyyy-HH-mm";
 
     public static final String MESSAGE_ADD_APPOINTMENT_SUCCESS = "Added Appointment to Person: %1$s";
+    public static final String MESSAGE_OVERLAPPING_APPOINTMENT =
+            "Appointment overlaps with another pre-existing appointment! Please check your schedule and try again";
     private final Index index;
     private final Appointment appointment;
     /**
@@ -59,6 +61,7 @@ public class AddAppointmentCommand extends Command {
         if (index.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
+
         Person personToEdit = lastShownList.get(index.getZeroBased());
         Person editedPerson = new Person(
                 personToEdit.getName(),
@@ -69,6 +72,10 @@ public class AddAppointmentCommand extends Command {
                 personToEdit.getNotes(),
                 appointment
         );
+
+        if (model.hasOverlappingAppointment(editedPerson)) {
+            throw new CommandException(MESSAGE_OVERLAPPING_APPOINTMENT);
+        }
 
         // Update the person in the model
         model.setPerson(personToEdit, editedPerson);

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -94,4 +94,14 @@ public interface Model {
      * Updates the filter of the sorted appointment list to filter by the given {@code predicate}.
      */
     void updateFilteredAppointmentList(Predicate<Person> predicate);
+
+    /** Returns an unmodifiable view of the all appointment list */
+    ObservableList<Person> getAllAppointmentsList();
+
+    /**
+     * Updates the filter of the all appointment list to filter by the given {@code predicate}.
+     */
+    void updateAllAppointmentsList(Predicate<Person> predicate);
+
+    boolean hasOverlappingAppointment(Person newAppointmentPerson);
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -187,10 +187,12 @@ public class ModelManager implements Model {
         for (Person person : allAppointmentsList) {
             LocalDateTime existingStart = person.getAppointmentStart();
             LocalDateTime existingEnd = person.getAppointmentEnd();
+
             boolean startsBeforeExistingEnds = newStart.isBefore(existingEnd);
             boolean endsAfterExistingStarts = newEnd.isAfter(existingStart);
             boolean startsAtSameTime = newStart.isEqual(existingStart);
             boolean endsAtSameTime = newEnd.isEqual(existingEnd);
+
             if ((startsBeforeExistingEnds && endsAfterExistingStarts) || startsAtSameTime || endsAtSameTime) {
                 return true;
             }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -182,7 +182,7 @@ public class ModelManager implements Model {
     @Override
     public boolean hasOverlappingAppointment(Person newAppointmentPerson) {
         LocalDateTime newStart = newAppointmentPerson.getAppointmentStart();
-        LocalDateTime newEnd = newAppointmentPerson.getAppointmentEnd(); // Assuming Person has getAppointmentEnd()
+        LocalDateTime newEnd = newAppointmentPerson.getAppointmentEnd();
 
         for (Person person : allAppointmentsList) {
             LocalDateTime existingStart = person.getAppointmentStart();

--- a/src/main/java/seedu/address/model/appointment/Appointment.java
+++ b/src/main/java/seedu/address/model/appointment/Appointment.java
@@ -42,6 +42,8 @@ public class Appointment {
         return this.end;
     }
 
+    //public boolean doesOverlap ()
+
     @Override
     public boolean equals(Object other) {
         if (other == this) {

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -169,6 +169,21 @@ public class AddCommandTest {
         public ObservableList<Person> getSortedAppointmentList() {
             throw new AssertionError("This method should not be called");
         }
+
+        @Override
+        public ObservableList<Person> getAllAppointmentsList() {
+            throw new AssertionError("This method should not be called");
+        }
+
+        @Override
+        public void updateAllAppointmentsList(Predicate<Person> predicate) {
+            throw new AssertionError("This method should not be called");
+        }
+
+        @Override
+        public boolean hasOverlappingAppointment(Person newAppointmentPerson) {
+            throw new AssertionError("This method should not be called");
+        }
     }
 
     /**


### PR DESCRIPTION
As WardWatch is a app for a single user, it does not make sense for one doctor to have overlapping appointments at a particular time

Hence in this PR, I've made it such that a new appointment can only be added if it does not overlap with any existing appointment