### PR TITLE
Fix addnotes 

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddNotesCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddNotesCommand.java
@@ -57,7 +57,7 @@ public class AddNotesCommand extends Command {
         Person personToEdit = lastShownList.get(index.getZeroBased());
         Person editedPerson = new Person(
                 personToEdit.getName(), personToEdit.getId(), personToEdit.getWard(),
-                personToEdit.getDiagnosis(), personToEdit.getMedication(), notes);
+                personToEdit.getDiagnosis(), personToEdit.getMedication(), notes, personToEdit.getAppointment());
 
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);


### PR DESCRIPTION
The previous implementation of addnotes command removes the appointment from the patient its adding its notes to if they have one.

In this PR i have resolved that issue